### PR TITLE
Fix bug where downloading a +2GB file over HTTPS fails at exactly 2GB

### DIFF
--- a/httpd.h
+++ b/httpd.h
@@ -192,7 +192,7 @@ static void inline close_on_exec(int fd)
 #ifdef USE_SSL
 extern int ssl_read(struct REQUEST *req, char *buf, int len);
 extern int ssl_write(struct REQUEST *req, char *buf, int len);
-extern int ssl_blk_write(struct REQUEST *req, int offset, int len);
+extern int ssl_blk_write(struct REQUEST *req, off_t offset, size_t len);
 extern void init_ssl(void);
 extern void open_ssl_session(struct REQUEST *req);
 #endif

--- a/ssl.c
+++ b/ssl.c
@@ -69,12 +69,6 @@ int ssl_blk_write(struct REQUEST *req, int offset, int len)
     int  rc;
     char buf[4096];
 
-    if (lseek(req->bfd, offset, SEEK_SET) == -1) {
-	if (debug)
-	    perror("lseek");
-	return -1;
-    }
-
     if (len > sizeof(buf))
 	len = sizeof(buf);
     rc = read(req->bfd, buf, len);

--- a/ssl.c
+++ b/ssl.c
@@ -64,10 +64,15 @@ int ssl_write(struct REQUEST *req, char *buf, int len)
     return rc;
 }
 
-int ssl_blk_write(struct REQUEST *req, int offset, int len)
+int ssl_blk_write(struct REQUEST *req, off_t offset, size_t len)
 {
     int  rc;
     char buf[4096];
+
+    if (lseek(req->bfd, offset, SEEK_SET) == -1) {
+        if (debug) perror("lseek");
+        return -1;
+    }
 
     if (len > sizeof(buf))
 	len = sizeof(buf);


### PR DESCRIPTION
Fixes #2 by changing `ssl_blk_write`'s arguments from `int` to `off_t` and `size_t`.