### PR TITLE
fix possible timing attack along with a few typo

### DIFF
--- a/ls.c
+++ b/ls.c
@@ -39,7 +39,7 @@ xgetpwuid(uid_t uid)
     int i;
 
     if (do_chroot)
-	return NULL; /* would'nt work anyway .. */
+	return NULL; /* wouldn't work anyway .. */
 
     for (i = 0; i < used; i++) {
 	if (uids[i] == uid)
@@ -77,7 +77,7 @@ xgetgrgid(gid_t gid)
     int i;
 
     if (do_chroot)
-	return NULL; /* would'nt work anyway .. */
+	return NULL; /* wouldn't work anyway .. */
 
     for (i = 0; i < used; i++) {
 	if (gids[i] == gid)
@@ -445,7 +445,7 @@ get_dir(struct REQUEST *req, char *filename)
 	    /* reached cache size limit -> free last element */
 #if 0
 	    if (this->next != NULL) {
-		fprintf(stderr,"panic: this should'nt happen (%s:%d)\n",
+		fprintf(stderr,"panic: this shouldn't happen (%s:%d)\n",
 			__FILE__, __LINE__);
 		exit(1);
 	    }

--- a/request.c
+++ b/request.c
@@ -347,6 +347,55 @@ static int sanity_checks(struct REQUEST *req)
     return 0;
 }
 
+/* tested with:
+ printf("%d\n", basic_password_match("", ""));
+ printf("%d\n", basic_password_match("aaaa", ""));
+ printf("%d\n", basic_password_match("", "aaaa"));
+ printf("%d\n", basic_password_match("aaa", "aab"));
+ printf("%d\n", basic_password_match("aaa", "bbb"));
+ printf("%d\n", basic_password_match("aaaaaa", "aa"));
+ printf("%d\n", basic_password_match("aa", "aaaaaa"));
+ printf("%d\n", basic_password_match("a", "a"));
+ printf("%d\n", basic_password_match("aa", "aa"));
+ printf("%d\n", basic_password_match("aaa", "aaa"));
+*/
+int basic_password_match(const char *input, const char *password)
+{
+    char unequal = 0;
+    unsigned int i = 0, j = 0;
+
+    /* special case: input or password is "" (null byte) */
+    if (!input[0] || !password[0]) return 0;
+
+    while (1) {
+
+        /* set the flag if any of the character mismatched */
+        unequal |= input[i] ^ password[j];
+
+        /* move on to next character */
+        i++;j++;
+
+        /* break if either input[] or password[] reaches 0x00 */
+        if (input[i] && password[j]) {
+            ;
+        } else {
+            break;
+        }
+
+    }
+
+    /*
+     valid if: (input[i],password[j] is 0x00) and (all compared characters match)
+     (input[i] == 0x00) and (password[j] == 0x00) checks whether the length are equal
+    */
+
+    if (!input[i] && !password[j] && !unequal) {
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
 void
 parse_request(struct REQUEST *req)
 {
@@ -478,7 +527,7 @@ parse_request(struct REQUEST *req)
 	return;
 
     /* check basic auth */
-    if (NULL != userpass && 0 != strcmp(userpass,req->auth)) {
+    if (NULL != userpass && !basic_password_match(userpass,req->auth)) {
 	mkerror(req,401,1);
 	return;
     }

--- a/request.c
+++ b/request.c
@@ -598,7 +598,7 @@ parse_request(struct REQUEST *req)
 	    strcat(req->path,"/");
 	    mkredirect(req);
 	} else {
-	    /* anything else is'nt allowed here */
+	    /* anything else isn't allowed here */
 	    mkerror(req,403,1);
 	}
 	return;

--- a/webfsd.c
+++ b/webfsd.c
@@ -294,7 +294,7 @@ access_log(struct REQUEST *req, time_t now)
 /*
  * loglevel usage
  *   ERR    : fatal errors (which are followed by exit(1))
- *   WARNING: this should'nt happen error (oom, ...)
+ *   WARNING: this shouldn't happen error (oom, ...)
  *   NOTICE : start/stop of the daemon
  *   INFO   : "normal" errors (canceled downloads, timeouts,
  *            stuff what happens all the time)


### PR DESCRIPTION
## side channel attack mitigation
Basic auth timing attacks in other http server implementation shares the same pattern with webfsd, it will be better to replace early-return comparison with constant-time comparison.
some other case:
 - [CVE-2024-23771](https://nvd.nist.gov/vuln/detail/CVE-2024-23771) and its corresponding [patch](https://github.com/emikulic/darkhttpd/commit/f477619d49f3c4de9ad59bd194265a48ddc03f04)
 - [PSV-2020-0365](https://kb.netgear.com/000062646/Security-Advisory-for-Multiple-HTTPd-Authentication-Vulnerabilities-on-DGN2200v1) and detailed [blog post](https://www.microsoft.com/en-us/security/blog/2021/06/30/microsoft-finds-new-netgear-firmware-vulnerabilities-that-could-lead-to-identity-theft-and-full-system-compromise/) from Microsoft research team
## typo correction
some words are misspelt